### PR TITLE
HHH-11152 Adding ByteBuddy JAR to module.xml

### DIFF
--- a/hibernate-orm-modules/src/main/modules/org/hibernate/core/module.xml
+++ b/hibernate-orm-modules/src/main/modules/org/hibernate/core/module.xml
@@ -10,6 +10,7 @@
         <resource-root path="hibernate-core-${version}.jar"/>
         <resource-root path="hibernate-envers-${version}.jar"/>
         <resource-root path="javassist-${javassistVersion}.jar"/>
+        <resource-root path="byte-buddy-${byteBuddyVersion}.jar"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
Hi @raphw this fixes some of the test issues I saw on your branch. They were all related to running integration tests on WildFly using Arquillian. The module.xml was missing a declaration of the ByteBuddy JAR, hence the BB classes couldn't be found. During testing, the WildFly server is unpacked into _build/wildfly-<VERSION>_, I could find the cause of the issue in _standalone/logs/server.log_.

I'm now getting some errors in the OSGi module, I assume ByteBuddy needs to be added here, too. I need to look into that separately. Do you provide an OSGi manifest within the ByteBuddy JAR?